### PR TITLE
fix `implied_bound_entailment` future compat lint

### DIFF
--- a/src/assertions/map.rs
+++ b/src/assertions/map.rs
@@ -118,7 +118,7 @@ where
         }
     }
 
-    fn key_set(&self) -> Subject<'a, Keys<K, V>, (), R> {
+    fn key_set(&self) -> Subject<Keys<K, V>, (), R> {
         self.new_owned_subject(
             self.actual().keys(),
             Some(format!("{}.keys()", self.description_or_expr())),


### PR DESCRIPTION
Hey :wave: this crate unintentionally relied on a soundness bug in the Rust compiler, see https://github.com/rust-lang/rust/issues/105572 for more info. This lint will be a hard error in a future release and is fixed by this PR.