### PR TITLE
Add contains_entry assertion for the map

### DIFF
--- a/src/assertions/map.rs
+++ b/src/assertions/map.rs
@@ -58,6 +58,7 @@ where
         BK: Borrow<K>,
         K: Eq + Hash + Debug;
 
+    /// Checks that the subject has entry with the given `key` and `value`.
     fn contains_entry<BK, BV>(&self, key: BK, value: BV) -> R
     where
         BK: Borrow<K>,


### PR DESCRIPTION
I created a `contains_entry` assertions that should be convenient for finding if specific entry is contained in the `Map`. Existing API covers the key interactions but I think this method will prove useful for more elaborate cases.