### PR TITLE
Fix build on latest rust toolchain

### DIFF
--- a/src/assertions/float.rs
+++ b/src/assertions/float.rs
@@ -188,7 +188,7 @@ mod tests {
         assert_that!(check_that!(0.1).is_approx_equal_to(0.3)).facts_are(vec![
             Fact::new("expected", "0.3"),
             Fact::new("but was", "0.1"),
-            Fact::new("outside tolerance", "0.00000301"),
+            Fact::new("outside tolerance", "3.01e-6"),
         ])
     }
 }

--- a/src/assertions/map.rs
+++ b/src/assertions/map.rs
@@ -168,7 +168,7 @@ where
         }
     }
 
-    fn key_set(&self) -> Subject<'a, Keys<K, V>, (), R> {
+    fn key_set(&self) -> Subject<Keys<K, V>, (), R> {
         self.new_owned_subject(
             self.actual().keys(),
             Some(format!("{}.keys()", self.description_or_expr())),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@
 extern crate num_traits;
 
 pub use assertions::basic::{ComparableAssertion, EqualityAssertion};
+pub use assertions::boolean::BooleanAssertion;
 #[cfg(feature = "float")]
 pub use assertions::float::FloatAssertion;
 pub use assertions::iterator::IteratorAssertion;


### PR DESCRIPTION
Addresses #6 on latest rust toolchain. Build is also failing due to not exposing boolean assertions which is fixed as well.

Reproduced build failure:

```
error: impl method assumes more implied bounds than the corresponding trait method
   --> src/assertions/map.rs:171:16
    |
171 |     fn key_set(&self) -> Subject<'a, Keys<K, V>, (), R> {
    |                ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this type to make the impl signature compatible: `Subject<'_, std::collections::hash_map::Keys<'_, K, V>, (), R>`
```

Test failures:

```
failures:

---- assertions::float::tests::is_approx_equal_to stdout ----
thread 'assertions::float::tests::is_approx_equal_to' panicked at 'assertion failed: src/assertions/float.rs:188:9
value of      : check_that!(0.1).is_approx_equal_to(0.3).facts()
missing (1)   : [KeyValue { key: "outside tolerance", value: "0.00000301" }]
unexpected (1): [KeyValue { key: "outside tolerance", value: "3.01e-6" }]
---
expected      : [KeyValue { key: "expected", value: "0.3" }, KeyValue { key: "but was", value: "0.1" }, KeyValue { key: "outside tolerance", value: "0.00000301" }]
actual        : [KeyValue { key: "expected", value: "0.3" }, KeyValue { key: "but was", value: "0.1" }, KeyValue { key: "outside tolerance", value: "3.01e-6" }]', src/base.rs:279:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

```
error[E0599]: no method named `is_true` found for struct `Subject` in the current scope
  --> src/assertions/boolean.rs:23:20
   |
6  | assert_that!(true).is_true();
   |                    ^^^^^^^ method not found in `Subject<'_, bool, (), ()>`
   |
  ::: /Users/kelebra/CLionProjects/assertor/src/assertions/boolean.rs:28:8
   |
28 |     fn is_true(&self) -> R;
   |        ------- the method is available for `Subject<'_, bool, (), ()>` here
   |
   = help: items from traits can only be used if the trait is in scope
```

After the fix:

```
kelebra@Oleksiis-Air assertor % cargo build     
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s

kelebra@Oleksiis-Air assertor % cargo test   
test result: ok. 48 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.20s
```