### PR TITLE
Add map diff struct and implement new assertion

### DIFF
--- a/src/assertions/map.rs
+++ b/src/assertions/map.rs
@@ -67,6 +67,7 @@ where
         K: Eq + Hash + Debug,
         V: Eq + Debug;
 
+    /// Checks that the subject contains all entries from `expected`.
     fn contains_all<BM>(&self, expected: BM) -> R
     where
         BM: Borrow<HashMap<K, V>>,

--- a/src/assertions/map.rs
+++ b/src/assertions/map.rs
@@ -21,6 +21,7 @@ use std::hash::Hash;
 use crate::assertions::basic::EqualityAssertion;
 use crate::assertions::iterator::check_is_empty;
 use crate::base::{AssertionApi, AssertionResult, AssertionStrategy, Subject};
+use crate::diff::{MapComparison, MapValueDiff};
 
 /// Trait for map assertion.
 ///
@@ -63,6 +64,12 @@ where
     where
         BK: Borrow<K>,
         BV: Borrow<V>,
+        K: Eq + Hash + Debug,
+        V: Eq + Debug;
+
+    fn contains_all<BM>(&self, expected: BM) -> R
+    where
+        BM: Borrow<HashMap<K, V>>,
         K: Eq + Hash + Debug,
         V: Eq + Debug;
 
@@ -166,6 +173,74 @@ where
                 )
                 .do_fail()
         }
+    }
+
+    fn contains_all<BM>(&self, expected: BM) -> R
+    where
+        BM: Borrow<HashMap<K, V>>,
+        K: Eq + Hash + Debug,
+        V: Eq + Debug,
+    {
+        let expected_map = expected.borrow();
+        let diff = MapComparison::from_hash_maps(self.actual(), expected_map);
+        if diff.common.len() == expected_map.len() {
+            return self.new_result().do_ok();
+        }
+        let mut result = self.new_result();
+        if !diff.exclusive_right.is_empty() {
+            result = result
+                .add_fact(
+                    "expected to contain all entries",
+                    format!(
+                        "but {} {} not found",
+                        diff.exclusive_right.len(),
+                        if diff.exclusive_right.len() == 1 {
+                            "entry"
+                        } else {
+                            "entries"
+                        }
+                    ),
+                )
+                .add_splitter();
+            for (key, value) in diff.exclusive_right {
+                result =
+                    result.add_fact("entry was not found", format!("{:?} -> {:?}", key, value));
+            }
+        }
+        if !diff.different_values.is_empty() {
+            if !result.facts().is_empty() {
+                result = result.add_splitter();
+            }
+            result = result
+                .add_fact(
+                    "expected to contain the same entries",
+                    format!(
+                        "but found {} {} different",
+                        diff.different_values.len(),
+                        if diff.different_values.len() == 1 {
+                            "entry that is"
+                        } else {
+                            "entries that are"
+                        }
+                    ),
+                )
+                .add_splitter();
+            for MapValueDiff {
+                key,
+                left_value,
+                right_value,
+            } in diff.different_values
+            {
+                result = result.add_fact(
+                    format!("key {:?} was mapped to an unexpected value", key),
+                    format!(
+                        "expected value {:?}, but found {:?}",
+                        right_value, left_value
+                    ),
+                );
+            }
+        }
+        return result.do_fail();
     }
 
     fn key_set(&self) -> Subject<Keys<K, V>, (), R> {
@@ -304,5 +379,56 @@ mod tests {
             .fact_keys()
             .contains(&"though it did contain keys".to_string());
         // Skip test for value because key order is not stable.
+    }
+
+    #[test]
+    fn contains_all() {
+        let mut map_abc: HashMap<&str, &str> = HashMap::new();
+        map_abc.insert("a", "1");
+        map_abc.insert("b", "2");
+        map_abc.insert("c", "3");
+        assert_that!(map_abc).contains_all(HashMap::from([("a", "1")]));
+        assert_that!(map_abc).contains_all(HashMap::from([("a", "1"), ("b", "2")]));
+
+        // case 1: missing key
+        let result = check_that!(map_abc).contains_all(HashMap::from([("not exist", "1")]));
+        assert_that!(result).facts_are_at_least(vec![
+            Fact::new("expected to contain all entries", "but 1 entry not found"),
+            Fact::new_splitter(),
+            Fact::new("entry was not found", r#""not exist" -> "1""#),
+        ]);
+
+        // case 2: mismatched entries
+        let result = check_that!(map_abc).contains_all(HashMap::from([("c", "5")]));
+        assert_that!(result).facts_are_at_least(vec![
+            Fact::new(
+                "expected to contain the same entries",
+                "but found 1 entry that is different",
+            ),
+            Fact::new_splitter(),
+            Fact::new(
+                r#"key "c" was mapped to an unexpected value"#,
+                r#"expected value "5", but found "3""#,
+            ),
+        ]);
+
+        // case 3: both mismatched and absent key
+        let result =
+            check_that!(map_abc).contains_all(HashMap::from([("not exist", "1"), ("c", "5")]));
+        assert_that!(result).facts_are_at_least(vec![
+            Fact::new("expected to contain all entries", "but 1 entry not found"),
+            Fact::new_splitter(),
+            Fact::new("entry was not found", r#""not exist" -> "1""#),
+            Fact::new_splitter(),
+            Fact::new(
+                "expected to contain the same entries",
+                "but found 1 entry that is different",
+            ),
+            Fact::new_splitter(),
+            Fact::new(
+                r#"key "c" was mapped to an unexpected value"#,
+                r#"expected value "5", but found "3""#,
+            ),
+        ]);
     }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::hash::Hash;
+
+pub(crate) struct MapValueDiff<K: PartialEq + Hash + Debug, V: Eq + Debug> {
+    pub(crate) key: K,
+    pub(crate) left_value: V,
+    pub(crate) right_value: V,
+}
+
+pub(crate) struct MapComparison<K: PartialEq + Hash + Debug, V: Eq + Debug> {
+    pub(crate) exclusive_left: Vec<(K, V)>,
+    pub(crate) exclusive_right: Vec<(K, V)>,
+    pub(crate) different_values: Vec<MapValueDiff<K, V>>,
+    pub(crate) common: Vec<(K, V)>,
+}
+
+impl<K: Eq + PartialEq + Hash + Debug, V: Eq + Debug> MapComparison<K, V> {
+    pub(crate) fn from_hash_maps<'a>(
+        left: &'a HashMap<K, V>,
+        right: &'a HashMap<K, V>,
+    ) -> MapComparison<&'a K, &'a V> {
+        let mut exclusive_left = vec![];
+        let mut exclusive_right = vec![];
+        let mut different_values = vec![];
+        let mut common = vec![];
+
+        for (key, value) in left {
+            match right.get(key) {
+                Some(rv) if value == rv => {
+                    common.push((key, value));
+                }
+                Some(rv) => different_values.push(MapValueDiff {
+                    key,
+                    left_value: value,
+                    right_value: rv,
+                }),
+                None => {
+                    exclusive_left.push((key, value));
+                }
+            }
+        }
+
+        for (key, value) in right {
+            if !left.contains_key(key) {
+                exclusive_right.push((key, value));
+            }
+        }
+
+        MapComparison {
+            exclusive_left,
+            exclusive_right,
+            different_values,
+            common,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::diff::MapComparison;
+    use std::collections::HashMap;
+
+    #[test]
+    fn diff_empty_maps() {
+        let left: HashMap<&str, i32> = HashMap::from([]);
+        let right: HashMap<&str, i32> = HashMap::from([]);
+        let result = MapComparison::from_hash_maps(&left, &right);
+        assert!(result.common.is_empty());
+        assert!(result.exclusive_left.is_empty());
+        assert!(result.exclusive_right.is_empty());
+    }
+
+    #[test]
+    fn map_diff_left_exclusive() {
+        let left: HashMap<&str, i32> = HashMap::from([("123", 2)]);
+        let right: HashMap<&str, i32> = HashMap::from([]);
+        let result = MapComparison::from_hash_maps(&left, &right);
+        assert!(result.common.is_empty());
+        assert_eq!(result.exclusive_left, vec![(&"123", &2)]);
+        assert!(result.exclusive_right.is_empty());
+    }
+
+    #[test]
+    fn map_diff_right_exclusive() {
+        let left: HashMap<&str, i32> = HashMap::from([]);
+        let right: HashMap<&str, i32> = HashMap::from([("123", 2)]);
+        let result = MapComparison::from_hash_maps(&left, &right);
+        assert!(result.common.is_empty());
+        assert!(result.exclusive_left.is_empty());
+        assert_eq!(result.exclusive_right, vec![(&"123", &2)]);
+    }
+
+    #[test]
+    fn map_diff_common() {
+        let left: HashMap<&str, i32> = HashMap::from([("123", 2)]);
+        let right: HashMap<&str, i32> = HashMap::from([("123", 2)]);
+        let result = MapComparison::from_hash_maps(&left, &right);
+        assert_eq!(result.common, vec![(&"123", &2)]);
+        assert!(result.exclusive_left.is_empty());
+        assert!(result.exclusive_right.is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub use base::{AssertionResult, AssertionStrategy, Fact, Location, Subject};
 
 mod assertions;
 mod base;
+mod diff;
 
 /// Module for testing the assertor library itself. Expected to be used by library developers.
 #[cfg(any(test, doc, feature = "testing"))]


### PR DESCRIPTION
This PR adds a common place for the diff-like structures. To jump-start the module I added `MapComparison` struct that will encapsulate differences between 2 hash maps. New functionality is used for the new `contains_all` assertion on maps.