### PR TITLE
Add sequence comparison struct. Update diff module.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ categories = ["development-tools::testing", "development-tools::debugging"]
 [dependencies]
 num-traits = { version = "0.2.15", optional = true }
 
+[dev-dependencies]
+test-case = "3.1.0"
+
 [features]
 default = ["float"]
 float = ["num-traits"]

--- a/src/assertions/iterator.rs
+++ b/src/assertions/iterator.rs
@@ -282,15 +282,15 @@ where
         let comparison = SequenceComparison::from_iter(
             self.actual().clone(),
             expected_iter.clone(),
-            SequenceOrderComparison::Exact,
+            SequenceOrderComparison::Strict,
         );
         if comparison.are_same() {
             self.new_result().do_ok()
         } else {
             feed_facts_about_item_diff(
                 self.new_result(),
-                comparison.exclusive_right,
-                comparison.exclusive_left,
+                comparison.missing,
+                comparison.extra,
                 self.actual().clone(),
                 expected_iter,
             )
@@ -305,7 +305,7 @@ where
         let comparison = SequenceComparison::from_iter(
             self.actual().clone(),
             expected_iter.clone(),
-            SequenceOrderComparison::Exact,
+            SequenceOrderComparison::Strict,
         );
         if comparison.are_equal() {
             self.new_result().do_ok()
@@ -325,8 +325,8 @@ where
         } else {
             feed_facts_about_item_diff(
                 self.new_result(),
-                comparison.exclusive_right,
-                comparison.exclusive_left,
+                comparison.missing,
+                comparison.extra,
                 self.actual().clone(),
                 expected_iter,
             )
@@ -346,7 +346,7 @@ where
         if comparison.contains_all() {
             self.new_result().do_ok()
         } else {
-            let missing = comparison.exclusive_right;
+            let missing = comparison.missing;
             self.new_result()
                 .add_fact(
                     format!("missing ({})", missing.len()),
@@ -428,7 +428,7 @@ where
                 )
                 .do_fail()
         } else {
-            let missing = comparison.exclusive_right;
+            let missing = comparison.missing;
             self.new_result()
                 .add_fact(
                     format!("missing ({})", missing.len()),

--- a/src/assertions/iterator.rs
+++ b/src/assertions/iterator.rs
@@ -284,7 +284,7 @@ where
             expected_iter.clone(),
             SequenceOrderComparison::Strict,
         );
-        if comparison.are_same() {
+        if comparison.contains_exactly() {
             self.new_result().do_ok()
         } else {
             feed_facts_about_item_diff(
@@ -307,9 +307,9 @@ where
             expected_iter.clone(),
             SequenceOrderComparison::Strict,
         );
-        if comparison.are_equal() {
+        if comparison.contains_exactly() && comparison.order_preserved {
             self.new_result().do_ok()
-        } else if comparison.are_same() && !comparison.order_preserved {
+        } else if comparison.contains_exactly() && !comparison.order_preserved {
             self.new_result()
                 .add_simple_fact("contents match, but order was wrong")
                 .add_splitter()

--- a/src/assertions/map.rs
+++ b/src/assertions/map.rs
@@ -23,7 +23,7 @@ use crate::assertions::iterator::{
     check_contains, check_does_not_contain, check_is_empty, check_is_not_empty,
 };
 use crate::base::{AssertionApi, AssertionResult, AssertionStrategy, Subject};
-use crate::diff::{MapComparison, MapValueDiff};
+use crate::diff::map::{MapComparison, MapValueDiff};
 
 /// Trait for map assertion.
 ///

--- a/src/assertions/map.rs
+++ b/src/assertions/map.rs
@@ -293,8 +293,8 @@ where
                 .add_splitter();
             for MapValueDiff {
                 key,
-                left_value,
-                right_value,
+                actual_value: left_value,
+                expected_value: right_value,
             } in diff.different_values
             {
                 result = result.add_fact(

--- a/src/assertions/map.rs
+++ b/src/assertions/map.rs
@@ -253,7 +253,7 @@ where
             return self.new_result().do_ok();
         }
         let mut result = self.new_result();
-        if !diff.exclusive_right.is_empty() {
+        if !diff.missing.is_empty() {
             result = result
                 .add_fact(
                     format!(
@@ -263,12 +263,12 @@ where
                     ),
                     format!(
                         "but {} {} not found",
-                        diff.exclusive_right.len(),
-                        pluralize(diff.exclusive_right.len(), "entry", "entries")
+                        diff.missing.len(),
+                        pluralize(diff.missing.len(), "entry", "entries")
                     ),
                 )
                 .add_splitter();
-            for (key, value) in diff.exclusive_right {
+            for (key, value) in diff.missing {
                 result =
                     result.add_fact("entry was not found", format!("{:?} -> {:?}", key, value));
             }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -250,7 +250,7 @@ pub(crate) mod iter {
         }
     }
 
-    // TODO: add quickcheck and parameterized (test_case / rstest) tests; for now covered with public API tests
+    // TODO: add quickcheck and/or parameterized (test_case / rstest) tests; for now covered with public API tests
     #[cfg(test)]
     mod tests {
         use super::SequenceComparison;

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,103 +1,252 @@
-use std::collections::HashMap;
-use std::fmt::Debug;
-use std::hash::Hash;
-
-pub(crate) struct MapValueDiff<K: PartialEq + Hash + Debug, V: Eq + Debug> {
-    pub(crate) key: K,
-    pub(crate) left_value: V,
-    pub(crate) right_value: V,
-}
-
-pub(crate) struct MapComparison<K: PartialEq + Hash + Debug, V: Eq + Debug> {
-    pub(crate) exclusive_left: Vec<(K, V)>,
-    pub(crate) exclusive_right: Vec<(K, V)>,
-    pub(crate) different_values: Vec<MapValueDiff<K, V>>,
-    pub(crate) common: Vec<(K, V)>,
-}
-
-impl<K: Eq + PartialEq + Hash + Debug, V: Eq + Debug> MapComparison<K, V> {
-    pub(crate) fn from_hash_maps<'a>(
-        left: &'a HashMap<K, V>,
-        right: &'a HashMap<K, V>,
-    ) -> MapComparison<&'a K, &'a V> {
-        let mut exclusive_left = vec![];
-        let mut exclusive_right = vec![];
-        let mut different_values = vec![];
-        let mut common = vec![];
-
-        for (key, value) in left {
-            match right.get(key) {
-                Some(rv) if value == rv => {
-                    common.push((key, value));
-                }
-                Some(rv) => different_values.push(MapValueDiff {
-                    key,
-                    left_value: value,
-                    right_value: rv,
-                }),
-                None => {
-                    exclusive_left.push((key, value));
-                }
-            }
-        }
-
-        for (key, value) in right {
-            if !left.contains_key(key) {
-                exclusive_right.push((key, value));
-            }
-        }
-
-        MapComparison {
-            exclusive_left,
-            exclusive_right,
-            different_values,
-            common,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::diff::MapComparison;
+pub(crate) mod map {
     use std::collections::HashMap;
+    use std::fmt::Debug;
+    use std::hash::Hash;
 
-    #[test]
-    fn diff_empty_maps() {
-        let left: HashMap<&str, i32> = HashMap::from([]);
-        let right: HashMap<&str, i32> = HashMap::from([]);
-        let result = MapComparison::from_hash_maps(&left, &right);
-        assert!(result.common.is_empty());
-        assert!(result.exclusive_left.is_empty());
-        assert!(result.exclusive_right.is_empty());
+    /// Difference for a single key in a Map-like data structure.
+    pub(crate) struct MapValueDiff<K: Eq + Hash + Debug, V: PartialEq + Debug> {
+        pub(crate) key: K,
+        pub(crate) left_value: V,
+        pub(crate) right_value: V,
     }
 
-    #[test]
-    fn map_diff_left_exclusive() {
-        let left: HashMap<&str, i32> = HashMap::from([("123", 2)]);
-        let right: HashMap<&str, i32> = HashMap::from([]);
-        let result = MapComparison::from_hash_maps(&left, &right);
-        assert!(result.common.is_empty());
-        assert_eq!(result.exclusive_left, vec![(&"123", &2)]);
-        assert!(result.exclusive_right.is_empty());
+    /// Disjoint representation and commonalities between two Map-like data structures.
+    pub(crate) struct MapComparison<K: Eq + Hash + Debug, V: PartialEq + Debug> {
+        pub(crate) exclusive_left: Vec<(K, V)>,
+        pub(crate) exclusive_right: Vec<(K, V)>,
+        pub(crate) different_values: Vec<MapValueDiff<K, V>>,
+        pub(crate) common: Vec<(K, V)>,
     }
 
-    #[test]
-    fn map_diff_right_exclusive() {
-        let left: HashMap<&str, i32> = HashMap::from([]);
-        let right: HashMap<&str, i32> = HashMap::from([("123", 2)]);
-        let result = MapComparison::from_hash_maps(&left, &right);
-        assert!(result.common.is_empty());
-        assert!(result.exclusive_left.is_empty());
-        assert_eq!(result.exclusive_right, vec![(&"123", &2)]);
+    // TODO: how would this look like for the `BTreeMap`?
+    impl<K: Eq + Hash + Debug, V: PartialEq + Debug> MapComparison<K, V> {
+        pub(crate) fn from_hash_maps<'a>(
+            left: &'a HashMap<K, V>,
+            right: &'a HashMap<K, V>,
+        ) -> MapComparison<&'a K, &'a V> {
+            let mut exclusive_left = vec![];
+            let mut exclusive_right = vec![];
+            let mut different_values = vec![];
+            let mut common = vec![];
+
+            for (key, value) in left {
+                match right.get(key) {
+                    Some(rv) if value == rv => {
+                        common.push((key, value));
+                    }
+                    Some(rv) => different_values.push(MapValueDiff {
+                        key,
+                        left_value: value,
+                        right_value: rv,
+                    }),
+                    None => {
+                        exclusive_left.push((key, value));
+                    }
+                }
+            }
+
+            for (key, value) in right {
+                if !left.contains_key(key) {
+                    exclusive_right.push((key, value));
+                }
+            }
+
+            MapComparison {
+                exclusive_left,
+                exclusive_right,
+                different_values,
+                common,
+            }
+        }
     }
 
-    #[test]
-    fn map_diff_common() {
-        let left: HashMap<&str, i32> = HashMap::from([("123", 2)]);
-        let right: HashMap<&str, i32> = HashMap::from([("123", 2)]);
-        let result = MapComparison::from_hash_maps(&left, &right);
-        assert_eq!(result.common, vec![(&"123", &2)]);
-        assert!(result.exclusive_left.is_empty());
-        assert!(result.exclusive_right.is_empty());
+    #[cfg(test)]
+    mod tests {
+        use std::collections::HashMap;
+
+        use crate::diff::map::MapComparison;
+
+        #[test]
+        fn diff_empty_maps() {
+            let left: HashMap<&str, i32> = HashMap::from([]);
+            let right: HashMap<&str, i32> = HashMap::from([]);
+            let result = MapComparison::from_hash_maps(&left, &right);
+            assert!(result.common.is_empty());
+            assert!(result.exclusive_left.is_empty());
+            assert!(result.exclusive_right.is_empty());
+        }
+
+        #[test]
+        fn map_diff_left_exclusive() {
+            let left: HashMap<&str, i32> = HashMap::from([("123", 2)]);
+            let right: HashMap<&str, i32> = HashMap::from([]);
+            let result = MapComparison::from_hash_maps(&left, &right);
+            assert!(result.common.is_empty());
+            assert_eq!(result.exclusive_left, vec![(&"123", &2)]);
+            assert!(result.exclusive_right.is_empty());
+        }
+
+        #[test]
+        fn map_diff_right_exclusive() {
+            let left: HashMap<&str, i32> = HashMap::from([]);
+            let right: HashMap<&str, i32> = HashMap::from([("123", 2)]);
+            let result = MapComparison::from_hash_maps(&left, &right);
+            assert!(result.common.is_empty());
+            assert!(result.exclusive_left.is_empty());
+            assert_eq!(result.exclusive_right, vec![(&"123", &2)]);
+        }
+
+        #[test]
+        fn map_diff_common() {
+            let left: HashMap<&str, i32> = HashMap::from([("123", 2)]);
+            let right: HashMap<&str, i32> = HashMap::from([("123", 2)]);
+            let result = MapComparison::from_hash_maps(&left, &right);
+            assert_eq!(result.common, vec![(&"123", &2)]);
+            assert!(result.exclusive_left.is_empty());
+            assert!(result.exclusive_right.is_empty());
+        }
+    }
+}
+
+pub(crate) mod iter {
+    use std::fmt::Debug;
+
+    /// Differences between two Sequence-like structures.
+    pub(crate) struct SequenceComparison<T: PartialEq + Debug> {
+        pub(crate) order_preserved: bool,
+        pub(crate) exclusive_left: Vec<T>,
+        pub(crate) exclusive_right: Vec<T>,
+    }
+
+    pub(crate) enum SequenceOrderComparison {
+        Relative,
+        Exact,
+    }
+
+    impl<T: PartialEq + Debug> SequenceComparison<T> {
+        pub(crate) fn are_same(&self) -> bool {
+            self.exclusive_left.is_empty() && self.exclusive_right.is_empty()
+        }
+
+        pub(crate) fn contains_all(&self) -> bool {
+            self.exclusive_right.is_empty()
+        }
+
+        pub(crate) fn are_equal(&self) -> bool {
+            self.are_same() && self.order_preserved
+        }
+
+        pub(crate) fn from_iter<
+            ICL: Iterator<Item = T> + Clone,
+            ICR: Iterator<Item = T> + Clone,
+        >(
+            left: ICL,
+            right: ICR,
+            sequence_order: SequenceOrderComparison,
+        ) -> SequenceComparison<T> {
+            match sequence_order {
+                SequenceOrderComparison::Exact => {
+                    Self::strict_order_comparison(left.clone(), right.clone())
+                }
+                SequenceOrderComparison::Relative => {
+                    Self::relative_order_comparison(left.clone(), right.clone())
+                }
+            }
+        }
+
+        pub(self) fn strict_order_comparison<
+            ICL: Iterator<Item = T> + Clone,
+            ICR: Iterator<Item = T> + Clone,
+        >(
+            mut actual_iter: ICL,
+            mut expected_iter: ICR,
+        ) -> SequenceComparison<T> {
+            let mut extra: Vec<T> = vec![];
+            let mut missing: Vec<T> = vec![];
+            let mut order_preserved = true;
+            let move_element = |el: T, source: &mut Vec<T>, target: &mut Vec<T>| {
+                if let Some(idx) = source.iter().position(|e: &T| e.eq(&el)) {
+                    source.remove(idx);
+                } else {
+                    target.push(el);
+                }
+            };
+            loop {
+                match (actual_iter.next(), expected_iter.next()) {
+                    (Some(actual_elem), Some(expect_elem)) => {
+                        if actual_elem.eq(&expect_elem) {
+                            continue;
+                        }
+                        order_preserved = false;
+                        move_element(expect_elem, &mut extra, &mut missing);
+                        move_element(actual_elem, &mut missing, &mut extra);
+                    }
+                    (None, Some(expect_elem)) => {
+                        move_element(expect_elem, &mut extra, &mut missing);
+                    }
+                    (Some(actual_elem), None) => {
+                        move_element(actual_elem, &mut missing, &mut extra);
+                    }
+                    (None, None) => break,
+                }
+            }
+            SequenceComparison {
+                order_preserved,
+                exclusive_left: extra,
+                exclusive_right: missing,
+            }
+        }
+
+        pub(self) fn relative_order_comparison<
+            ICL: Iterator<Item = T> + Clone,
+            ICR: Iterator<Item = T> + Clone,
+        >(
+            mut actual_iter: ICL,
+            mut expected_iter: ICR,
+        ) -> SequenceComparison<T> {
+            let mut actual_value = actual_iter.next();
+            let mut expected_value = expected_iter.next();
+            let mut missing: Vec<T> = vec![];
+            let mut extra: Vec<T> = vec![];
+            loop {
+                if expected_value.is_none() {
+                    extra.extend(actual_iter);
+                    break;
+                }
+                if actual_value.is_none() {
+                    missing.push(expected_value.unwrap());
+                    missing.extend(expected_iter);
+                    break;
+                }
+                if actual_value.eq(&expected_value) {
+                    actual_value = actual_iter.next();
+                    expected_value = expected_iter.next();
+                } else {
+                    extra.push(actual_value.unwrap());
+                    actual_value = actual_iter.next();
+                }
+            }
+            let order_preserved = missing.is_empty();
+
+            // check out of order elements.
+            if !missing.is_empty() {
+                for extra_elem in extra.iter() {
+                    if let Some(idx) = missing.iter().position(|m: &T| m.eq(extra_elem)) {
+                        missing.remove(idx);
+                    }
+                }
+            }
+
+            SequenceComparison {
+                order_preserved,
+                exclusive_left: extra,
+                exclusive_right: missing,
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        // TODO: add quickcheck and parameterized (test_case / rstest) tests; for now covered with public API tests
     }
 }


### PR DESCRIPTION
This PR introduces `SequenceComparison` struct similarly to the `MapComparison` by extracting sequence comparison logic to the `diff` module. For the latter to happen `diff` module was split into `map` and `iter`.