### PR TITLE
Added build script to keep license headers up-to-date

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/google/assertor"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.67.0"
+build = "build.rs"
 
 keywords = ["assert", "assertions", "testing", "unit"]
 categories = ["development-tools::testing", "development-tools::debugging"]
@@ -24,3 +25,7 @@ default = ["float"]
 float = ["num-traits"]
 testing = []
 
+[build-dependencies]
+chrono = "0.4.26"
+walkdir = "2.3.3"
+lazy_static = "1.4.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,102 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::env;
+
+fn main() {
+    env::current_dir()
+        .map(|root| license::check_and_generate_license_headers(root))
+        .unwrap()
+}
+
+mod license {
+    use chrono::Datelike;
+    use lazy_static::lazy_static;
+    use std::collections::HashSet;
+    use std::fs;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+    use walkdir::WalkDir;
+
+    lazy_static! {
+        static ref YEAR: String = chrono::Utc::now().year().to_string();
+        static ref LICENCE_HEADER_PREFIX: String = "// Copyright".to_string();
+        static ref LICENSE_HEADER: String = format!(
+            r#"{} {} Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+"#,
+            LICENCE_HEADER_PREFIX.to_string(),
+            YEAR.to_string()
+        );
+        static ref LICENSED_EXTENSIONS: HashSet<String> = HashSet::from(["rs".to_string()]);
+        static ref SKIP_DIR_NAMES: HashSet<String> = HashSet::from(["target".to_string()]);
+    }
+
+    pub(crate) fn check_and_generate_license_headers(root: PathBuf) {
+        for entry in WalkDir::new(root).into_iter().filter_map(|e| e.ok()) {
+            let path = entry.path();
+            let extension = path.extension();
+            if extension.is_none() {
+                continue;
+            }
+            if LICENSED_EXTENSIONS.contains(extension.unwrap().to_str().unwrap()) {
+                // process supported file extension
+                if let Some(mut content) = needs_license_header(path) {
+                    let mut new_content = LICENSE_HEADER.to_string();
+                    new_content.push_str(content.as_str());
+                    fs::write(path, new_content.as_bytes());
+                }
+            }
+            // skip files without extension
+        }
+    }
+
+    /// Return Some(content) if file needs license appended.
+    fn needs_license_header(path: &Path) -> Option<String> {
+        let content = fs::read_to_string(path).unwrap();
+        if content.starts_with(&LICENSE_HEADER.to_string()) {
+            None
+        } else if content.starts_with(&LICENCE_HEADER_PREFIX.to_string()) {
+            // assume file starts with outdated license comment,
+            // find first line break that is uncommented
+            let split = content.split_inclusive("\n");
+            let mut index: usize = 0;
+            for line in split {
+                if line == "\n" {
+                    return Some(content[index..].to_string());
+                } else {
+                    index = index + line.len();
+                }
+            }
+            return None;
+        } else {
+            // no license comment, append licence at the start with the linebreak
+            let mut space = "\n".to_string();
+            space.push_str(content.as_str());
+            Some(space)
+        }
+    }
+}

--- a/src/assertions/basic.rs
+++ b/src/assertions/basic.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/assertions/boolean.rs
+++ b/src/assertions/boolean.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/assertions/float.rs
+++ b/src/assertions/float.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/assertions/iterator.rs
+++ b/src/assertions/iterator.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/assertions/map.rs
+++ b/src/assertions/map.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/assertions/mod.rs
+++ b/src/assertions/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/assertions/option.rs
+++ b/src/assertions/option.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/assertions/result.rs
+++ b/src/assertions/result.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/assertions/set.rs
+++ b/src/assertions/set.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/assertions/string.rs
+++ b/src/assertions/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/assertions/testing.rs
+++ b/src/assertions/testing.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/assertions/vec.rs
+++ b/src/assertions/vec.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub(crate) mod map {
     use std::collections::HashMap;
     use std::fmt::Debug;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Added a `build.rs` file to keep license headers up-to-date as well as generate license headers for new files added during development. This is still very raw but I was wondering if there is an interest for this functionality. Script is ~100 lines of code and all the changes in the PR are generated by it. As you can see it covers year update and generation of the header for the new files.