### PR TITLE
Add missing license header to diff.rs

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub(crate) mod map {
     use std::collections::HashMap;
     use std::fmt::Debug;


### PR DESCRIPTION
Simplifying #34 to only add missing comment.