### PR TITLE
Add wrapping of the `actual` and the `expected` messages in the `iter`

### DIFF
--- a/src/assertions/iterator.rs
+++ b/src/assertions/iterator.rs
@@ -312,8 +312,8 @@ where
             self.new_result()
                 .add_simple_fact("contents match, but order was wrong")
                 .add_splitter()
-                .add_raw_key_values_fact("expected", expected_iter.collect())
-                .add_raw_key_values_fact("actual", self.actual().clone().collect())
+                .add_formatted_values_fact("expected", expected_iter.collect())
+                .add_formatted_values_fact("actual", self.actual().clone().collect())
                 .do_fail()
         } else {
             feed_facts_about_item_diff(
@@ -345,8 +345,8 @@ where
                     format!("{:?}", missing),
                 )
                 .add_splitter()
-                .add_raw_key_values_fact("expected to contain at least", expected_iter.collect())
-                .add_raw_key_values_fact("but was", self.actual().clone().collect())
+                .add_formatted_values_fact("expected to contain at least", expected_iter.collect())
+                .add_formatted_values_fact("but was", self.actual().clone().collect())
                 // Idea: implement near_miss_obj
                 // .add_fact("tough it did contain", format!("{:?}", near_miss_obj))
                 .do_fail()
@@ -378,8 +378,8 @@ where
                     format!("{:?}", intersection),
                 )
                 .add_splitter()
-                .add_raw_key_values_fact("expected to contain none of", elements.collect())
-                .add_raw_key_values_fact("but was", self.actual().clone().clone().collect())
+                .add_formatted_values_fact("expected to contain none of", elements.collect())
+                .add_formatted_values_fact("but was", self.actual().clone().collect())
                 .do_fail()
         }
     }
@@ -398,11 +398,11 @@ where
         } else if comparison.contains_all() {
             self.new_result()
                 .add_simple_fact("required elements were all found, but order was wrong")
-                .add_raw_key_values_fact(
+                .add_formatted_values_fact(
                     "expected order for required elements",
                     expected_iter.clone().collect(),
                 )
-                .add_raw_key_values_fact("but was", self.actual().clone().collect())
+                .add_formatted_values_fact("but was", self.actual().clone().collect())
                 .do_fail()
         } else {
             let missing = comparison.missing;
@@ -414,8 +414,8 @@ where
                 // Idea: implement near_miss_obj
                 // .add_fact("tough it did contain", format!("{:?}", near_miss_obj))
                 .add_splitter()
-                .add_raw_key_values_fact("expected to contain at least", expected_iter.collect())
-                .add_raw_key_values_fact("but was", self.actual().clone().collect())
+                .add_formatted_values_fact("expected to contain at least", expected_iter.collect())
+                .add_formatted_values_fact("but was", self.actual().clone().collect())
                 .do_fail()
         }
     }
@@ -459,7 +459,7 @@ where
         assertion_result
             .add_simple_fact("expected to be empty")
             .add_splitter()
-            .add_raw_key_values_fact("actual", actual_iter.collect())
+            .add_formatted_values_fact("actual", actual_iter.collect())
             .do_fail()
     }
 }
@@ -497,7 +497,7 @@ where
         assertion_result
             .add_fact("expected to contain", format!("{:?}", element))
             .add_simple_fact("but did not")
-            .add_raw_key_values_fact("though it did contain", actual_iter.clone().collect())
+            .add_formatted_values_fact("though it did contain", actual_iter.clone().collect())
             .do_fail()
     }
 }
@@ -516,7 +516,7 @@ where
         assertion_result
             .add_fact("expected to not contain", format!("{:?}", element))
             .add_simple_fact("but element was found")
-            .add_raw_key_values_fact("though it did contain", actual_iter.clone().collect())
+            .add_formatted_values_fact("though it did contain", actual_iter.clone().collect())
             .do_fail()
     } else {
         assertion_result.do_ok()
@@ -554,8 +554,8 @@ pub(crate) fn feed_facts_about_item_diff<
         result = result.add_splitter();
     }
     result
-        .add_raw_key_values_fact("expected", expected_iter.clone().collect())
-        .add_raw_key_values_fact("actual", actual_iter.clone().collect())
+        .add_formatted_values_fact("expected", expected_iter.clone().collect())
+        .add_formatted_values_fact("actual", actual_iter.clone().collect())
 }
 
 pub(crate) fn check_has_length<I, T, R>(

--- a/src/assertions/map.rs
+++ b/src/assertions/map.rs
@@ -466,7 +466,7 @@ mod tests {
         assert_that!(check_that!(HashMap::from([("a", "b")])).is_empty()).facts_are(vec![
             Fact::new_simple_fact("expected to be empty"),
             Fact::new_splitter(),
-            Fact::new("actual", "[\"a\"]"),
+            Fact::new_multi_value_fact("actual", vec!["\"a\""]),
         ])
     }
 

--- a/src/assertions/set.rs
+++ b/src/assertions/set.rs
@@ -51,7 +51,8 @@ use crate::EqualityAssertion;
 /// ```
 pub trait SetAssertion<'a, S, T, R> {
     /// Checks that the subject has the given length.
-    fn has_length(&self, length: usize) -> R;
+    fn has_length(&self, length: usize) -> R where
+        T: Debug;
 
     /// Checks that the subject is empty.
     fn is_empty(&self) -> R
@@ -99,19 +100,8 @@ where
     where
         T: PartialEq + Eq + Debug + Hash,
     {
-        if self.actual().contains(expected.borrow()) {
-            self.new_result().do_ok()
-        } else {
-            self.new_result()
-                .add_fact("expected to contain", format!("{:?}", expected.borrow()))
-                .add_simple_fact("but did not")
-                .add_fact(
-                    "though it did contain",
-                    // TODO: better error message
-                    format!("{:?}", self.actual().iter().collect::<Vec<_>>()),
-                )
-                .do_fail()
-        }
+        self.new_owned_subject(self.actual().iter(), None, ())
+            .contains(expected.borrow())
     }
 
     fn does_not_contain<B>(&self, element: B) -> R

--- a/src/assertions/set.rs
+++ b/src/assertions/set.rs
@@ -51,9 +51,7 @@ use crate::EqualityAssertion;
 /// ```
 pub trait SetAssertion<'a, S, T, R> {
     /// Checks that the subject has the given length.
-    fn has_length(&self, length: usize) -> R
-    where
-        T: Debug;
+    fn has_length(&self, length: usize) -> R;
 
     /// Checks that the subject is empty.
     fn is_empty(&self) -> R

--- a/src/assertions/set.rs
+++ b/src/assertions/set.rs
@@ -51,7 +51,8 @@ use crate::EqualityAssertion;
 /// ```
 pub trait SetAssertion<'a, S, T, R> {
     /// Checks that the subject has the given length.
-    fn has_length(&self, length: usize) -> R where
+    fn has_length(&self, length: usize) -> R
+    where
         T: Debug;
 
     /// Checks that the subject is empty.
@@ -149,7 +150,7 @@ mod tests {
         assert_that!(check_that!(HashSet::from_iter(vec![1].iter())).is_empty()).facts_are(vec![
             Fact::new_simple_fact("expected to be empty"),
             Fact::new_splitter(),
-            Fact::new("actual", "[1]"),
+            Fact::new_multi_value_fact("actual", vec!["1"]),
         ]);
     }
 

--- a/src/assertions/testing.rs
+++ b/src/assertions/testing.rs
@@ -112,8 +112,8 @@ where
             .iter()
             .flat_map(|fact| match fact {
                 Fact::KeyValue { key, .. } => Some(key),
-                Fact::Value { .. } => None,
-                Fact::Splitter => None,
+                Fact::KeyValues { key, .. } => Some(key),
+                _ => None,
             })
             .collect();
         self.new_owned_subject(
@@ -169,8 +169,8 @@ mod tests {
             Fact::new("value of", "failed.facts()"),
             Fact::new("unexpected (1)", r#"[Value { value: "not same" }]"#),
             Fact::new_splitter(),
-            Fact::new("expected", "[]"),
-            Fact::new("actual", r#"[Value { value: "not same" }]"#),
+            Fact::new_multi_value_fact::<&str, &str>("expected", vec![]),
+            Fact::new_multi_value_fact("actual", vec!["Value { value: \"not same\" }"]),
         ]);
     }
 }

--- a/src/assertions/vec.rs
+++ b/src/assertions/vec.rs
@@ -233,7 +233,7 @@ mod tests {
         assert_that!(check_that!(vec![1, 2, 3]).contains(&10)).facts_are(vec![
             Fact::new("expected to contain", "10"),
             Fact::new_simple_fact("but did not"),
-            Fact::new("though it did contain", r#"[1, 2, 3]"#),
+            Fact::new_multi_value_fact("though it did contain", vec!["1", "2", "3"]),
         ]);
     }
 
@@ -250,8 +250,8 @@ mod tests {
             vec![
                 Fact::new_simple_fact("contents match, but order was wrong"),
                 Fact::new_splitter(),
-                Fact::new("expected", "[1, 2, 3]"),
-                Fact::new("actual", "[2, 1, 3]"),
+                Fact::new_multi_value_fact("expected", vec!["1", "2", "3"]),
+                Fact::new_multi_value_fact("actual", vec!["2", "1", "3"]),
             ],
         )
     }
@@ -264,7 +264,7 @@ mod tests {
         assert_that!(check_that!(vec![1]).is_empty()).facts_are(vec![
             Fact::new_simple_fact("expected to be empty"),
             Fact::new_splitter(),
-            Fact::new("actual", "[1]"),
+            Fact::new_multi_value_fact("actual", vec!["1"]),
         ])
     }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -309,7 +309,7 @@ impl AssertionResult {
     }
 
     #[inline]
-    pub fn add_raw_key_values_fact<K: Into<String>, V: Debug>(
+    pub fn add_formatted_values_fact<K: Into<String>, V: Debug>(
         mut self,
         key: K,
         values: Vec<V>,
@@ -615,7 +615,7 @@ s  : hort"#
         assert_eq!(
             AssertionResult::new(&Some(Location::new("foo.rs", 123, 456)))
                 .add_fact("looooong key", "align indent")
-                .add_raw_key_values_fact("kv_key", vec!["short_value"])
+                .add_formatted_values_fact("kv_key", vec!["short_value"])
                 .generate_message(),
             r#"assertion failed: foo.rs:123:456
 looooong key: align indent
@@ -624,7 +624,7 @@ kv_key      : [ "short_value" ]"#
         assert_eq!(
             AssertionResult::new(&Some(Location::new("foo.rs", 123, 456)))
                 .add_fact("looooong key", "align indent")
-                .add_raw_key_values_fact("kv_key", vec!["short_value", "Very long value is formatted using new lines, this is done to improve output readability."])
+                .add_formatted_values_fact("kv_key", vec!["short_value", "Very long value is formatted using new lines, this is done to improve output readability."])
                 .generate_message(),
             r#"assertion failed: foo.rs:123:456
 looooong key: align indent
@@ -635,14 +635,14 @@ kv_key      : [
         );
         assert_eq!(
             AssertionResult::new(&Some(Location::new("foo.rs", 123, 456)))
-                .add_raw_key_values_fact("kv_key", vec![1, 2, 3])
+                .add_formatted_values_fact("kv_key", vec![1, 2, 3])
                 .generate_message(),
             r#"assertion failed: foo.rs:123:456
 kv_key: [ 1, 2, 3 ]"#
         );
         assert_eq!(
             AssertionResult::new(&Some(Location::new("foo.rs", 123, 456)))
-                .add_raw_key_values_fact("kv_key", vec!["1", "2", "3"])
+                .add_formatted_values_fact("kv_key", vec!["1", "2", "3"])
                 .generate_message(),
             r#"assertion failed: foo.rs:123:456
 kv_key: [ "1", "2", "3" ]"#
@@ -654,14 +654,14 @@ kv_key: [ "1", "2", "3" ]"#
         }
         assert_eq!(
             AssertionResult::new(&Some(Location::new("foo.rs", 123, 456)))
-                .add_raw_key_values_fact(
+                .add_formatted_values_fact(
                     "kv_key_sht",
                     vec![LongOutputData {
                         val: None,
                         nested: vec!["123", "321"]
                     }]
                 )
-                .add_raw_key_values_fact(
+                .add_formatted_values_fact(
                     "kv_key_lng",
                     vec![
                         LongOutputData {


### PR DESCRIPTION
This is to address #30 for `iter`. Also delegated all methods in `set` to `iter` to implicitly support wrapping of the messages.