### PR TITLE
feat: add #[track_caller] to all assertion methods

### DIFF
--- a/src/assertions/basic.rs
+++ b/src/assertions/basic.rs
@@ -36,6 +36,7 @@ impl<S: PartialEq + Debug, R> EqualityAssertion<S, R> for Subject<'_, S, (), R>
 where
     AssertionResult: AssertionStrategy<R>,
 {
+    #[track_caller]
     fn is_equal_to<B: Borrow<S>>(&self, expected: B) -> R {
         if self.actual().eq(expected.borrow()) {
             self.new_result().do_ok()
@@ -46,6 +47,8 @@ where
                 .do_fail()
         }
     }
+
+    #[track_caller]
     fn is_not_equal_to<B: Borrow<S>>(&self, expected: B) -> R {
         if !self.actual().ne(expected.borrow()) {
             self.new_result().do_fail()
@@ -74,6 +77,7 @@ impl<S: PartialOrd + Debug, R> ComparableAssertion<S, R> for Subject<'_, S, (), 
 where
     AssertionResult: AssertionStrategy<R>,
 {
+    #[track_caller]
     fn is_at_least<B: Borrow<S>>(&self, expected: B) -> R {
         if self.actual().ge(expected.borrow()) {
             self.new_result().do_ok()
@@ -83,6 +87,7 @@ where
         }
     }
 
+    #[track_caller]
     fn is_at_most<B: Borrow<S>>(&self, expected: B) -> R {
         if self.actual().le(expected.borrow()) {
             self.new_result().do_ok()
@@ -92,6 +97,7 @@ where
         }
     }
 
+    #[track_caller]
     fn is_greater_than<B: Borrow<S>>(&self, expected: B) -> R {
         if self.actual().gt(expected.borrow()) {
             self.new_result().do_ok()
@@ -101,6 +107,7 @@ where
         }
     }
 
+    #[track_caller]
     fn is_less_than<B: Borrow<S>>(&self, expected: B) -> R {
         if self.actual().lt(expected.borrow()) {
             self.new_result().do_ok()

--- a/src/assertions/boolean.rs
+++ b/src/assertions/boolean.rs
@@ -35,6 +35,7 @@ impl<R> BooleanAssertion<R> for Subject<'_, bool, (), R>
 where
     AssertionResult: AssertionStrategy<R>,
 {
+    #[track_caller]
     fn is_true(&self) -> R {
         if *self.actual() {
             self.new_result().do_ok()
@@ -46,6 +47,7 @@ where
         }
     }
 
+    #[track_caller]
     fn is_false(&self) -> R {
         if !self.actual() {
             self.new_result().do_ok()

--- a/src/assertions/float.rs
+++ b/src/assertions/float.rs
@@ -106,6 +106,7 @@ where
         self
     }
 
+    #[track_caller]
     fn is_approx_equal_to<B: Borrow<S>>(&self, expected: B) -> R {
         let diff = (*self.actual() - *expected.borrow()).abs();
         let tolerance: S = self.option().abs_tol + self.option().rel_tol * *expected.borrow();
@@ -144,6 +145,7 @@ where
         )
     }
 
+    #[track_caller]
     fn is_approx_equal_to<B: Borrow<S>>(&self, expected: B) -> R
     where
         FloatTolerance<S>: Default,

--- a/src/assertions/iterator.rs
+++ b/src/assertions/iterator.rs
@@ -259,6 +259,7 @@ where
     S: Iterator<Item = T> + Clone,
     AssertionResult: AssertionStrategy<R>,
 {
+    #[track_caller]
     fn contains<B>(&self, element: B) -> R
     where
         B: Borrow<T>,
@@ -267,6 +268,7 @@ where
         check_contains(self.new_result(), self.actual().clone(), element.borrow())
     }
 
+    #[track_caller]
     fn does_not_contain<B>(&self, element: B) -> R
     where
         B: Borrow<T>,
@@ -275,6 +277,7 @@ where
         check_does_not_contain(self.new_result(), self.actual().clone(), element.borrow())
     }
 
+    #[track_caller]
     fn contains_exactly<EI: Iterator<Item = T> + Clone>(self, expected_iter: EI) -> R
     where
         T: PartialEq + Debug,
@@ -297,6 +300,7 @@ where
         }
     }
 
+    #[track_caller]
     fn contains_exactly_in_order<EI: Iterator<Item = T> + Clone>(self, expected_iter: EI) -> R
     where
         T: PartialEq + Debug,
@@ -326,6 +330,7 @@ where
         }
     }
 
+    #[track_caller]
     fn contains_all_of<EI: Iterator<Item = T> + Clone>(self, expected_iter: EI) -> R
     where
         T: PartialEq + Debug,
@@ -353,6 +358,7 @@ where
         }
     }
 
+    #[track_caller]
     fn does_not_contain_any<EI: Iterator<Item = T> + Clone>(&self, elements: EI) -> R
     where
         T: PartialEq + Debug,
@@ -384,6 +390,7 @@ where
         }
     }
 
+    #[track_caller]
     fn contains_all_of_in_order<EI: Iterator<Item = T> + Clone>(self, expected_iter: EI) -> R
     where
         T: PartialEq + Debug,
@@ -420,6 +427,7 @@ where
         }
     }
 
+    #[track_caller]
     fn is_empty(&self) -> R
     where
         T: Debug,
@@ -427,6 +435,7 @@ where
         check_is_empty(self.new_result(), self.actual().clone())
     }
 
+    #[track_caller]
     fn is_not_empty(&self) -> R
     where
         T: Debug,
@@ -434,6 +443,7 @@ where
         check_is_not_empty(self.new_result(), self.actual().clone())
     }
 
+    #[track_caller]
     fn has_length(&self, length: usize) -> R
     where
         T: Debug,

--- a/src/assertions/map.rs
+++ b/src/assertions/map.rs
@@ -133,6 +133,7 @@ impl<'a, K, V, R> MapAssertion<'a, K, V, R> for Subject<'a, HashMap<K, V>, (), R
 where
     AssertionResult: AssertionStrategy<R>,
 {
+    #[track_caller]
     fn has_length(&self, length: usize) -> R {
         self.new_subject(
             &self.actual().keys().len(),
@@ -142,6 +143,7 @@ where
         .is_equal_to(length)
     }
 
+    #[track_caller]
     fn is_empty(&self) -> R
     where
         K: Debug,
@@ -149,6 +151,7 @@ where
         check_is_empty(self.new_result(), self.actual().keys())
     }
 
+    #[track_caller]
     fn is_not_empty(&self) -> R
     where
         K: Debug,
@@ -156,6 +159,7 @@ where
         check_is_not_empty(self.new_result(), self.actual().keys())
     }
 
+    #[track_caller]
     fn contains_key<BK>(&self, key: BK) -> R
     where
         BK: Borrow<K>,
@@ -164,6 +168,7 @@ where
         check_contains(self.new_result(), self.actual().keys(), &key.borrow())
     }
 
+    #[track_caller]
     fn does_not_contain_key<BK>(&self, key: BK) -> R
     where
         BK: Borrow<K>,
@@ -172,6 +177,7 @@ where
         check_does_not_contain(self.new_result(), self.actual().keys(), &key.borrow())
     }
 
+    #[track_caller]
     fn contains_entry<BK, BV>(&self, key: BK, value: BV) -> R
     where
         BK: Borrow<K>,
@@ -214,6 +220,7 @@ where
         }
     }
 
+    #[track_caller]
     fn does_not_contain_entry<BK, BV>(&self, key: BK, value: BV) -> R
     where
         BK: Borrow<K>,
@@ -241,6 +248,7 @@ where
         }
     }
 
+    #[track_caller]
     fn contains_at_least<BM>(&self, expected: BM) -> R
     where
         BM: Borrow<HashMap<K, V>>,
@@ -264,6 +272,7 @@ where
             .do_fail()
     }
 
+    #[track_caller]
     fn does_not_contain_any<BM>(&self, expected: BM) -> R
     where
         BM: Borrow<HashMap<K, V>>,
@@ -285,6 +294,7 @@ where
         return self.new_result().do_ok();
     }
 
+    #[track_caller]
     fn contains_exactly<BM>(&self, expected: BM) -> R
     where
         BM: Borrow<HashMap<K, V>>,

--- a/src/assertions/option.rs
+++ b/src/assertions/option.rs
@@ -53,6 +53,7 @@ impl<'a, T, R> OptionAssertion<'a, T, R> for Subject<'a, Option<T>, (), R>
 where
     AssertionResult: AssertionStrategy<R>,
 {
+    #[track_caller]
     fn is_none(&self) -> R
     where
         T: PartialEq + Debug,
@@ -67,6 +68,7 @@ where
         }
     }
 
+    #[track_caller]
     fn is_some(&self) -> R
     where
         T: PartialEq + Debug,
@@ -81,6 +83,7 @@ where
         }
     }
 
+    #[track_caller]
     fn has_value<B>(&self, expected: B) -> R
     where
         B: Borrow<T>,

--- a/src/assertions/result.rs
+++ b/src/assertions/result.rs
@@ -53,6 +53,7 @@ impl<R, OK: Debug, ERR: Debug> ResultAssertion<R, OK, ERR> for Subject<'_, Resul
 where
     AssertionResult: AssertionStrategy<R>,
 {
+    #[track_caller]
     fn is_ok(&self) -> R {
         if self.actual().is_ok() {
             self.new_result().do_ok()
@@ -66,6 +67,7 @@ where
         }
     }
 
+    #[track_caller]
     fn is_err(&self) -> R {
         if self.actual().is_err() {
             self.new_result().do_ok()
@@ -79,6 +81,7 @@ where
         }
     }
 
+    #[track_caller]
     fn has_ok<B: Borrow<OK>>(&self, expected: B) -> R
     where
         OK: PartialEq,
@@ -98,6 +101,7 @@ where
         }
     }
 
+    #[track_caller]
     fn has_err<B: Borrow<ERR>>(&self, expected: B) -> R
     where
         ERR: PartialEq,

--- a/src/assertions/set.rs
+++ b/src/assertions/set.rs
@@ -79,6 +79,7 @@ impl<'a, T, R> SetAssertion<'a, HashSet<T>, T, R> for Subject<'a, HashSet<T>, ()
 where
     AssertionResult: AssertionStrategy<R>,
 {
+    #[track_caller]
     fn has_length(&self, length: usize) -> R {
         self.new_subject(
             &self.actual().len(),
@@ -88,6 +89,7 @@ where
         .is_equal_to(length)
     }
 
+    #[track_caller]
     fn is_empty(&self) -> R
     where
         T: Debug,
@@ -95,6 +97,7 @@ where
         check_is_empty(self.new_result(), self.actual().iter())
     }
 
+    #[track_caller]
     fn contains<B: Borrow<T>>(&self, expected: B) -> R
     where
         T: PartialEq + Eq + Debug + Hash,
@@ -103,6 +106,7 @@ where
             .contains(expected.borrow())
     }
 
+    #[track_caller]
     fn does_not_contain<B>(&self, element: B) -> R
     where
         B: Borrow<T>,
@@ -112,6 +116,7 @@ where
             .does_not_contain(element.borrow())
     }
 
+    #[track_caller]
     fn does_not_contain_any<B: Borrow<Vec<T>>>(&self, elements: B) -> R
     where
         T: PartialEq + Debug,

--- a/src/assertions/string.rs
+++ b/src/assertions/string.rs
@@ -47,11 +47,13 @@ impl<R> StringAssertion<R> for Subject<'_, String, (), R>
 where
     AssertionResult: AssertionStrategy<R>,
 {
+    #[track_caller]
     fn is_same_string_to<E: Into<String>>(&self, expected: E) -> R {
         let subject: Subject<String, (), R> = self.new_subject(self.actual(), None, ());
         EqualityAssertion::is_equal_to(&subject, expected.into())
     }
 
+    #[track_caller]
     fn contains<E: Into<String>>(&self, expected: E) -> R {
         let expected_str = expected.into();
         if self.actual().contains(&expected_str) {
@@ -64,6 +66,7 @@ where
         }
     }
 
+    #[track_caller]
     fn does_not_contain<E: Into<String>>(&self, value: E) -> R {
         let expected_str = value.into();
         if self.actual().contains(&expected_str) {
@@ -76,6 +79,7 @@ where
         }
     }
 
+    #[track_caller]
     fn starts_with<E: Into<String>>(&self, expected: E) -> R {
         let expected_str = expected.into();
         if self.actual().starts_with(&expected_str) {
@@ -88,6 +92,7 @@ where
         }
     }
 
+    #[track_caller]
     fn ends_with<E: Into<String>>(&self, expected: E) -> R {
         let expected_str = expected.into();
         if self.actual().ends_with(&expected_str) {

--- a/src/assertions/testing.rs
+++ b/src/assertions/testing.rs
@@ -61,6 +61,7 @@ impl<'a, R> CheckThatResultAssertion<'a, R> for Subject<'a, CheckThatResult, (),
 where
     AssertionResult: AssertionStrategy<R>,
 {
+    #[track_caller]
     fn facts_are<B: Borrow<Vec<Fact>>>(&self, expected: B) -> R {
         self.new_owned_subject(
             get_assertion_result(self).facts().iter(),
@@ -70,6 +71,7 @@ where
         .contains_exactly_in_order(expected.borrow().iter())
     }
 
+    #[track_caller]
     fn facts_are_at_least<B: Borrow<Vec<Fact>>>(&self, facts: B) -> R {
         self.new_owned_subject(
             get_assertion_result(self).facts().iter(),
@@ -79,6 +81,7 @@ where
         .contains_all_of_in_order(facts.borrow().iter())
     }
 
+    #[track_caller]
     fn fact_value_for_key<I: Into<String>>(&self, key: I) -> Subject<String, (), R> {
         let key_str = key.into();
         let assertion_result = get_assertion_result(self);
@@ -105,6 +108,7 @@ where
         )
     }
 
+    #[track_caller]
     fn fact_keys(&self) -> Subject<HashSet<&String>, (), R> {
         let assertion_result = get_assertion_result(self);
         let keys: HashSet<&String> = assertion_result

--- a/src/assertions/vec.rs
+++ b/src/assertions/vec.rs
@@ -158,6 +158,7 @@ impl<'a, T, R> VecAssertion<'a, Vec<T>, T, R> for Subject<'a, Vec<T>, (), R>
 where
     AssertionResult: AssertionStrategy<R>,
 {
+    #[track_caller]
     fn contains<B>(&self, element: B) -> R
     where
         B: Borrow<T>,
@@ -167,6 +168,7 @@ where
             .contains(element.borrow())
     }
 
+    #[track_caller]
     fn does_not_contain<B>(&self, element: B) -> R
     where
         B: Borrow<T>,
@@ -176,6 +178,7 @@ where
             .does_not_contain(element.borrow())
     }
 
+    #[track_caller]
     fn contains_exactly<B: Borrow<Vec<T>>>(self, expected_iter: B) -> R
     where
         T: PartialEq + Debug,
@@ -184,6 +187,7 @@ where
             .contains_exactly(expected_iter.borrow().iter())
     }
 
+    #[track_caller]
     fn contains_exactly_in_order<B: Borrow<Vec<T>>>(self, expected_iter: B) -> R
     where
         T: PartialEq + Debug,
@@ -192,6 +196,7 @@ where
             .contains_exactly_in_order(expected_iter.borrow().iter())
     }
 
+    #[track_caller]
     fn does_not_contain_any<B: Borrow<Vec<T>>>(&self, elements: B) -> R
     where
         T: PartialEq + Debug,
@@ -200,6 +205,7 @@ where
             .does_not_contain_any(elements.borrow().iter())
     }
 
+    #[track_caller]
     fn is_empty(&self) -> R
     where
         T: Debug,
@@ -207,6 +213,7 @@ where
         check_is_empty(self.new_result(), self.actual().iter())
     }
 
+    #[track_caller]
     fn is_not_empty(&self) -> R
     where
         T: Debug,
@@ -214,6 +221,7 @@ where
         check_is_not_empty(self.new_result(), self.actual().iter())
     }
 
+    #[track_caller]
     fn has_length(&self, length: usize) -> R {
         check_has_length(self.new_result(), self.actual().iter(), self.expr(), length)
     }

--- a/src/base.rs
+++ b/src/base.rs
@@ -276,6 +276,7 @@ pub trait AssertionStrategy<R> {
 }
 
 impl AssertionStrategy<()> for AssertionResult {
+    #[track_caller]
     fn do_fail(self) {
         std::panic::panic_any(self.generate_message());
     }


### PR DESCRIPTION
This enables the panic message to point to the call site, instead of the location within assertor the panic was generated.